### PR TITLE
Add missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,15 +9,23 @@
     "url": "https://github.com/synzen/Discord.RSS/issues"
   },
   "dependencies": {
+    "bufferutil": "^3.0.0",
     "cloudscraper": "^1.4.1",
     "discord.js": "^11.1.0",
     "entities": "^1.1.1",
+    "erlpack": "hammerandchisel/erlpack",
     "feedparser": "^2.1.0",
     "got": "^6.7.1",
+    "libsodium-wrappers": "^0.5.1",
     "moment": "^2.17.1",
     "moment-timezone": "^0.5.11",
+    "needle": "^1.6.0",
+    "node-opus": "^0.2.5",
+    "opusscript": "^0.0.3",
+    "sodium": "^2.0.1",
     "sqlite3": "^3.1.8",
-    "striptags": "^2.1.1"
+    "striptags": "^2.1.1",
+    "uws": "^0.14.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I was updating my testenv, these depends were throwing warnings with npm. Also added needle which would cause bot to fail to start.