### PR TITLE
Switch application base to alpine, remove expose of database port, re…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:alpine
 WORKDIR /usr/src/discord-rss
 COPY package*.json ./
 RUN npm install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
     image: mongo:latest
     volumes:
       - 'mongo:/data/db'
-    expose: 27017
+    expose:
+      - 27017
   discordrss:
     container_name: discord-rss
     restart: on-failure:10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,22 @@
 version: "3"
-volumes:
-  mongo:
 services:
   mongo:
-    container_name: discord-rss-mongo
-    # Use port 27018 instead of the default 27017 to prevent conflicts
-    command: mongod --port 27018
+    container_name: discord-rss-mongodb
+    restart: on-failure:5
+    command: mongod --port 27017
     # Uncomment below to hide mongo logs
     #logging:
     #  driver: none
-    image: mongo
+    image: mongo:latest
     volumes:
       - 'mongo:/data/db'
-    ports:
-      - "27018:27018"
-  discord-rss:
+    expose: 27017
+  discordrss:
     container_name: discord-rss
-    restart: always
+    restart: on-failure:10
     build: .
     links:
       - mongo
+
+volumes:
+  mongo:


### PR DESCRIPTION
Hello @synzen, made couple fixes to the setup, here is the list

- Added restart policies to both containers, the endless restart loop due to some error in configuration can drain Discord API limits and result bot ban, limiting to 5 restarts for mongodb and 10 restarts for application
- Removed `ports` which bind port to host, and added `expose` of mongodb port to linked application, so database is accessible only from application. To make a direct access to mongodb can add 

``` 
ports:
- random_host_port:27017
``` 
and use your preferred port without application and database reconfiguration

- Explicit set of version and images from mongodb and node, also node is set to alpine, which uses less space
- Removed `-` (dash) in service definition, this can cause issues between docker-compose versions, due to different name handling