### PR TITLE
Updated listener.js to use logger.js

### DIFF
--- a/util/listeners.js
+++ b/util/listeners.js
@@ -17,14 +17,14 @@ const EVENT_HANDLERS = {
 }
 let cmdsExtension
 if (fs.existsSync('./settings/commands.js')) {
-  try { cmdsExtension = require('../settings/commands.js') } catch (e) { console.log(`Error: Unable to load commands extension file. Reason:\n`, e) }
+  try { cmdsExtension = require('../settings/commands.js') } catch (e) { log.general.error(`Error: Unable to load commands extension file. Reason:\n`, e) }
   fs.watchFile('./settings/commands.js', (cur, prev) => {
     delete require.cache[require.resolve('../settings/commands.js')]
     try {
       cmdsExtension = require('../settings/commands.js')
-      console.log(`Commands extension file has been updated`)
+      log.general.success(`Commands extension file has been updated`)
     } catch (e) {
-      console.log(`Commands extension file was changed, but could not be updated. Reason:\n`, e)
+      log.general.warning(`Commands extension file was changed, but could not be updated. Reason:\n`, e)
     }
   })
 }


### PR DESCRIPTION
Messages emitted when attempting to load commands.js were previously using console.log, despite logger.js being required, and not used.
This PR replaces the calls to console.log with calls to the relevant logger functions.