### PR TITLE
Heroku Deployment Support

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
-worker: npm start
-web: Run worker not web
+bot: npm start

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Driven by the lack of comprehensive RSS bots available, I have decided to try my
 All documentation can be found at https://github.com/synzen/Discord.RSS/wiki.
 
 
+### Heroku Deployment
+
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
 ### Setting Up via Cloning Repository
 
 See https://github.com/synzen/Discord.RSS/wiki/Setup

--- a/app.json
+++ b/app.json
@@ -1,0 +1,31 @@
+{
+  "name": "Discord.RSS",
+  "description": "Discord RSS bot with customizable feeds",
+  "logo": "https://i.imgur.com/11zvdoc.png",
+  "website": "https://github.com/synzen/Discord.RSS",
+  "keywords": [
+    "discord",
+    "bot",
+    "rss",
+    "feed"
+  ],
+  "version": "3.0.0",
+  "addons": [
+    "mongolab"
+  ],
+  "env": {
+    "DISCORD_TOKEN": {
+      "description": "Discord bot token https://discordapp.com/developers/applications/"
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 0,
+      "size": "free"
+    },
+    "bot": {
+      "quantity": 1,
+      "size": "free"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "bugs": {
     "url": "https://github.com/synzen/Discord.RSS/issues"
   },
+  "scripts": {
+    "start": "node server.js"
+  },
   "dependencies": {
     "cloudscraper": "^1.4.1",
     "discord.js": "^11.3.2",
@@ -18,8 +21,8 @@
     "mongoose": "^5.0.2",
     "needle": "^1.6.0"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/synzen/Discord.RSS.git"
+  "engines": {
+    "node": "10.x",
+    "npm": "6.x"
   }
 }

--- a/server.js
+++ b/server.js
@@ -2,11 +2,13 @@ const DiscordRSS = require('./index.js')
 const config = require('./config.json')
 
 const drss = new DiscordRSS.Client({ readFileSchedules: true, setPresence: true })
-let token = config.bot.token
+let token = process.env.DISCORD_TOKEN || config.bot.token
 
 try {
   const override = require('./settings/configOverride.json')
   token = override.bot && override.bot.token ? override.bot.token : token
 } catch (err) {}
+
+config.database.uri = process.env.MONGODB_URI || config.database.uri
 
 drss.login(token)


### PR DESCRIPTION
With Heroku Button Deployment you don't need to have git or heroku cli. You can configure it straight through the Heroku web interface.

What I changed: 
* I defined a bot dyno. The "entrance point".  
* I added a Heroku Button to the ReadMe [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://www.heroku.com/deploy/?template=https://github.com/NNTin/Discord.RSS) (click it)
* I added an app.json: There it defines how many dyno it needs, what the environmental variables are, and added an mongodb add-on.
* I updated package.json: When the dyno is started it runs `node server.js`. Also I defined node and npm version.
* finally to make the connection to your project I hooked it up in your code in server.js

This was hastily written and could be structured better. But this gives you a good starting point how Heroku Button deployment works and can be extended to incorporate other configuration such as prefix, etc. You can made those configuration optional or required.

An example how Heroku Button works: 
For my [discord-twitter-bot](https://github.com/NNTin/discord-twitter-bot) I've also added a [Heroku Button](https://www.heroku.com/deploy/?template=https://github.com/NNTin/discord-twitter-bot) Deployment. Here is a video demonstration: https://www.youtube.com/watch?v=NwPcXBvStSI
This deployment process is much more user friendly.