### PR TITLE
Fix: Running the Discord bot twice

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: npm start
+bot: npm start

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 bot: npm start
+web: npm -v

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ There are multiple ways of integrating Discord.RSS programmatically - see [here]
 #### Customization Functions
  * [html-to-text](https://www.npmjs.com/package/html-to-text) - Convert HTML content
  * [moment-timezone](https://www.npmjs.com/package/moment-timezone) - Customizable timezones
- 
+
 ### Deploy to Heroku
 
 You can deploy in a simple way to Heroku using the button below.
 
-[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://dashboard.heroku.com/new?template=https://github.com/synzen/Discord.RSS/tree/dev)
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 *If you want to deploy manually you should go to the settings of your applications and add a "Config Var" DRSS_DISCORD_TOKEN with the token of your discord bot.*

--- a/app.json
+++ b/app.json
@@ -2,6 +2,13 @@
   "name": "Discord.RSS",
   "description": "Discord RSS bot with customizable feeds",
   "website": "https://github.com/synzen/Discord.RSS",
+  "logo": "https://i.imgur.com/11zvdoc.png",
+  "keywords": [
+    "discord",
+    "bot",
+    "rss",
+    "feed"
+  ],
   "addons": [
     "mongolab"
   ],
@@ -15,7 +22,7 @@
       "quantity": 0,
       "size": "free"
     },
-    "worker": {
+    "bot": {
       "quantity": 1,
       "size": "free"
     }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "bugs": {
     "url": "https://github.com/synzen/Discord.RSS/issues"
   },
+  "scripts": {
+    "start": "node server.js"
+  },
   "dependencies": {
     "cloudscraper": "^1.5.0",
     "discord.js": "^11.4.2",
@@ -22,5 +25,9 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/synzen/Discord.RSS.git"
+  },
+  "engines": {
+    "node": "10.x",
+    "npm": "6.x"
   }
 }


### PR DESCRIPTION
* specified engine and entry point in package.json
* using standard heroku button deploy link (heroku webpage can detect origin)
* fix for running the Discord bot twice (web dyno runs first, after 60 seconds it shuts down since it's not bound to a port) I specified a web worker that immediately shuts down.