### PR TITLE
Sanitize mentions in cleanup (prior to role logic)

### DIFF
--- a/structs/Article.js
+++ b/structs/Article.js
@@ -154,14 +154,9 @@ function cleanup (source, text, imgSrcs, anchorLinks, encoding) {
       }
     }
   })
-  
-  /** 
-    Sanitize mentions with zero-width character "\u200b" 
-    n.b. This does not affect subscribed roles or modify anything outside the scope of sanitizing Discord mentions in the raw RSS feed content
-  **/ 
-  text = text.replace(/@/g, '@' + String.fromCharCode(8203)) 
-  
-  text = text.replace(/\n\s*\n\s*\n/g, '\n\n') // Replace triple line breaks with double 
+
+  text = text.replace(/\n\s*\n\s*\n/g, '\n\n') // Replace triple line breaks with double
+    .replace(/@/g, '@' + String.fromCharCode(8203)) // Sanitize mentions with zero-width character "\u200b", does not affect subscribed roles or modify anything outside the scope of sanitizing Discord mentions in the raw RSS feed content
   const arr = text.split('\n')
   for (var q = 0; q < arr.length; ++q) arr[q] = arr[q].replace(/\s+$/, '') // Remove trailing spaces
   return arr.join('\n')

--- a/structs/Article.js
+++ b/structs/Article.js
@@ -156,6 +156,8 @@ function cleanup (source, text, imgSrcs, anchorLinks, encoding) {
   })
 
   text = text.replace(/\n\s*\n\s*\n/g, '\n\n') // Replace triple line breaks with double
+  text = text.replace(/`/g, '\`' + String.fromCharCode(8203))  // Sanitize mentions with zero-width character "\u200b"
+    .replace(/@/g, '@' + String.fromCharCode(8203)) // This does not affect subscribed roles or modify anything outside the scope of sanitizing Discord mentions in the raw RSS feed content
   const arr = text.split('\n')
   for (var q = 0; q < arr.length; ++q) arr[q] = arr[q].replace(/\s+$/, '') // Remove trailing spaces
   return arr.join('\n')

--- a/structs/Article.js
+++ b/structs/Article.js
@@ -154,10 +154,14 @@ function cleanup (source, text, imgSrcs, anchorLinks, encoding) {
       }
     }
   })
-
-  text = text.replace(/\n\s*\n\s*\n/g, '\n\n') // Replace triple line breaks with double
-  text = text.replace(/`/g, '\`' + String.fromCharCode(8203))  // Sanitize mentions with zero-width character "\u200b"
-    .replace(/@/g, '@' + String.fromCharCode(8203)) // This does not affect subscribed roles or modify anything outside the scope of sanitizing Discord mentions in the raw RSS feed content
+  
+  /** 
+    Sanitize mentions with zero-width character "\u200b" 
+    n.b. This does not affect subscribed roles or modify anything outside the scope of sanitizing Discord mentions in the raw RSS feed content
+  **/ 
+  text = text.replace(/@/g, '@' + String.fromCharCode(8203)) 
+  
+  text = text.replace(/\n\s*\n\s*\n/g, '\n\n') // Replace triple line breaks with double 
   const arr = text.split('\n')
   for (var q = 0; q < arr.length; ++q) arr[q] = arr[q].replace(/\s+$/, '') // Remove trailing spaces
   return arr.join('\n')


### PR DESCRIPTION
Per DM, opening PR. Sanitizes mentions in the raw article via. the `cleanup` function with a zero-width space. This makes all mentions (such as `@everyone` - that could be contained in the RSS body) not get triggered on Discord but does not affect the output, nor has any impact on subscribed roles, as that logic is done after this cleanup.