### PR TITLE
Added config vars for bot status and activity

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,7 +25,8 @@
 			"value": "~"
 		},
 		"DRSS_BOT_CONTROLLER_IDS": {
-			"description": "Owner ID(s), separate multiple with a comma."
+			"description": "Owner ID(s), separate multiple with a comma.",
+			"required": false
 		},
 		"DRSS_FEEDS_REFRESH_TIME_MINUTES": {
 			"description": "Refresh rate of your RSS feed bot.",

--- a/app.json
+++ b/app.json
@@ -25,8 +25,7 @@
 			"value": "~"
 		},
 		"DRSS_BOT_CONTROLLER_IDS": {
-			"description": "Owner ID(s), separate multiple with a comma.",
-			"required": false
+			"description": "Owner ID(s), separate multiple with a comma."
 		},
 		"DRSS_FEEDS_REFRESH_TIME_MINUTES": {
 			"description": "Refresh rate of your RSS feed bot.",
@@ -51,6 +50,22 @@
 		"DRSS_WEB_ENABLED": {
 			"description": "WARNING! If you enable this, make sure that this value is \"true\" and you fill in all of the DRSS_WEB_ and have read the WIKI thoroughly. Make sure to NOT use worker, but instead always use WEB in the sources tab. Finally use something to keep your web dyno up like uptimerobot (free online software).",
 			"value": "false"
+		},
+		"DRSS_BOT_STATUS": {
+			"description": "Choose from online, idle, dnd or invisible.",
+			"value": "online"
+		},
+		"DRSS_BOT_ACTIVITY_TYPE": {
+			"description": "Choose from PLAYING, LISTENING, STREAMING or WATCHING. Leave this blank if you don't want the bot to display a custom status.",
+			"required": false
+		},
+		"DRSS_BOT_ACTIVITY_NAME": {
+			"description": "Displayed next to the activity type. Leave this blank if you don't want the bot to display a custom status.",
+			"required": false
+		},
+		"DRSS_BOT_STREAM_URL": {
+			"description": "Stream URL for STREAMING activity. If you're not using the STREAMING activity type leave this blank.",
+			"required": false
 		}
 	},
 	"formation": {

--- a/config.js
+++ b/config.js
@@ -11,6 +11,10 @@ config.bot.prefix = process.env.DRSS_BOT_PREFIX || config.bot.prefix
 config.bot.controllerIds = process.env.DRSS_BOT_CONTROLLER_IDS ? process.env.DRSS_BOT_CONTROLLER_IDS.split(/\s*,\s*/) : config.bot.controllerIds
 config.feeds.refreshTimeMinutes = Number(process.env.DRSS_FEEDS_REFRESH_TIME_MINUTES) || config.feeds.refreshTimeMinutes
 config.feeds.defaultMessage = process.env.DRSS_FEEDS_DEFAULT_MESSAGE ? process.env.DRSS_FEEDS_DEFAULT_MESSAGE.replace(/\\n/g, '\n') : config.feeds.defaultMessage
+config.bot.status = process.env.DRSS_BOT_STATUS || config.bot.status
+config.bot.activityType = process.env.DRSS_BOT_ACTIVITY_TYPE || config.bot.activityType
+config.bot.activityName = process.env.DRSS_BOT_ACTIVITY_NAME || config.bot.activityName
+config.bot.streamActivityURL = process.env.DRSS_BOT_STREAM_URL || config.bot.streamActivityURL
 
 // Web
 config.web.enabled = process.env.DRSS_WEB_ENABLED === 'true' || config.web.enabled


### PR DESCRIPTION
Heroku restarts the bot every 24 hours, so if a custom status is set using the `setstatus` command, it will be removed on the next restart. I have added config vars for setting the bot status, activity type, activity name and stream activity URL (for STREAMING type).

I have also made the bot controller IDs required, as obviously if someone hosts his own instance of the bot he/she would want access to the owner commands as well. There is always a bot owner, so it makes sense for it to be required.