### PR TITLE
Add more env vars for Heroku deployments

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -36,6 +36,17 @@ config.bot.activityType = process.env.DRSS_BOT_ACTIVITY_TYPE || config.bot.activ
 config.bot.activityName = process.env.DRSS_BOT_ACTIVITY_NAME || config.bot.activityName
 config.bot.streamActivityURL = process.env.DRSS_BOT_STREAM_URL || config.bot.streamActivityURL
 
+// Optional env vars for Heroku deployments
+config.bot.locale = process.env.DRSS_BOT_LOCALE || config.bot.locale
+config.database.articlesExpire = process.env.DRSS_DATABASE_ARTICLESEXPIRE || config.database.articlesExpire
+config.database.guildBackupsExpire = process.env.DRSS_DATABASE_GUILDBACKUPSEXPIRE || config.database.guildBackupsExpire
+config.feeds.timezone = process.env.DRSS_FEEDS_TIMEZONE || config.feeds.timezone
+config.feeds.imgPreviews = process.env.DRSS_FEEDS_IMGPREVIEWS || config.feeds.imgPreviews
+config.feeds.imgLinksExistence = process.env.DRSS_FEEDS_IMGLINKSEXISTENCE || config.feeds.imgLinksExistence
+config.feeds.checkDates = process.env.DRSS_FEEDS_CHECKDATES || config.feeds.checkDates
+config.feeds.formatTables = process.env.DRSS_FEEDS_TABLEFORMAT || config.feeds.formatTables
+config.feeds.toggleRoleMentions = process.env.DRSS_BOT_TOGGLEROLEMENTIONS || config.feeds.toggleRoleMentions
+
 // Web
 config.web.enabled = process.env.DRSS_WEB_ENABLED === 'true' || config.web.enabled
 

--- a/src/config.js
+++ b/src/config.js
@@ -45,7 +45,7 @@ config.feeds.imgPreviews = process.env.DRSS_FEEDS_IMGPREVIEWS || config.feeds.im
 config.feeds.imgLinksExistence = process.env.DRSS_FEEDS_IMGLINKSEXISTENCE || config.feeds.imgLinksExistence
 config.feeds.checkDates = process.env.DRSS_FEEDS_CHECKDATES || config.feeds.checkDates
 config.feeds.formatTables = process.env.DRSS_FEEDS_TABLEFORMAT || config.feeds.formatTables
-config.feeds.toggleRoleMentions = process.env.DRSS_BOT_TOGGLEROLEMENTIONS || config.feeds.toggleRoleMentions
+config.feeds.toggleRoleMentions = process.env.DRSS_FEEDS_TOGGLEROLEMENTIONS || config.feeds.toggleRoleMentions
 
 // Web
 config.web.enabled = process.env.DRSS_WEB_ENABLED === 'true' || config.web.enabled

--- a/src/config.js
+++ b/src/config.js
@@ -46,6 +46,12 @@ config.feeds.imgLinksExistence = process.env.DRSS_FEEDS_IMGLINKSEXISTENCE || con
 config.feeds.checkDates = process.env.DRSS_FEEDS_CHECKDATES || config.feeds.checkDates
 config.feeds.formatTables = process.env.DRSS_FEEDS_TABLEFORMAT || config.feeds.formatTables
 config.feeds.toggleRoleMentions = process.env.DRSS_FEEDS_TOGGLEROLEMENTIONS || config.feeds.toggleRoleMentions
+config.feeds.dateFormat = process.env.DRSS_FEEDS_DATEFORMAT || config.feeds.dateFormat
+config.feeds.dateFallback = process.env.DRSS_FEEDS_DATEFALLBACK || config.feeds.dateFallback
+config.feeds.timeFallback = process.env.DRSS_FEEDS_TIMEFALLBACK || config.feeds.timeFallback
+config.feeds.notifyFail = process.env.DRSS_FEEDS_NOTIFYFAIL || config.feeds.notifyFail
+config.feeds.sendOldOnFirstCycle = process.env.DRSS_FEEDS_SENDOLDFIRSTCYCLE || config.feeds.sendOldOnFirstCycle
+config.feeds.cycleMaxAge = process.env.DRSS_FEEDS_CYCLEMAXAGE || config.feeds.cycleMaxAge
 
 // Web
 config.web.enabled = process.env.DRSS_WEB_ENABLED === 'true' || config.web.enabled


### PR DESCRIPTION
I have added env vars for many of the options available in config.json. These will be optional and won't be shown when someone initially deploys the bot via the Heroku button. Instead, the env var keys can be added on [this page](https://github.com/synzen/Discord.RSS/wiki/Configuration) in a new column labelled "Env var key".

Not only this will be very convenient for Heroku hosters, but will also help improve security, there would be less risk of people exposing their bot token in the config.json file should they wish to customise their bot even further.

Hope I haven't made any typos when editing the config.js file!